### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You can either add the library to your application as a library project or add t
 
 ```groovy
 dependencies {
-    compile 'com.jpardogo.listbuddies:library:(latest version)'
+    implementation 'com.jpardogo.listbuddies:library:(latest version)'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.